### PR TITLE
Use relative path for loading none_extra

### DIFF
--- a/lib/puppet/indirector/catalog/none.rb
+++ b/lib/puppet/indirector/catalog/none.rb
@@ -1,5 +1,5 @@
 require 'puppet/resource/catalog'
-require 'puppet/indirector/none_extra'
+load File.expand_path '../../none_extra.rb', __FILE__
 
 class Puppet::Resource::Catalog::None < Puppet::Indirector::None
   desc "Don't do anything"


### PR DESCRIPTION
For some reason (maybe I'm doing something wrong?) I get this error unless I change the require to relative:
```
Error: Could not autoload puppet/indirector/catalog/none: cannot load such file -- puppet/indirector/none_extra
Error: Could not prepare for execution: Could not autoload puppet/indirector/catalog/none: cannot load such file -- puppet/indirector/none_extra
```